### PR TITLE
applied workaround of ics files with TZID before DATE in DTSTART/DTEND

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Zum Einbinden eines Google Kalenders muss die Kalendereinstellung des Google Kal
 Known BUGS: Probleme mit gleichen UUIDs von iCal Einträgen (bedingt durch Bibliothek); sich wiederholende Termine, in welchen einzelne Termine ausgenommen werden funktionieren nicht. Die Bibliothek verarbeitet keine EXDATES.
 
 ## Changelog
+### 1.2.1 (2017-02-11)
+* (jens-maus) applied workaround of ics files with TZID before DATE in DTSTART/DTEND
+
 ### 1.2.0 (2016-07-23)
 * (bluefox) allow read from files
 * (bluefox) add tests

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,13 @@
 {
     "common": {
         "name":                     "ical",
-        "version":                  "1.2.0",
+        "version":                  "1.2.1",
         "news": {
+            "1.2.1": {
+                "en": "fix for ics files returning date strings",
+                "de": "fix for ics files returning date strings",
+                "ru": "fix for ics files returning date strings"
+            },
             "1.2.0": {
                 "en": "allow read from files",
                 "de": "allow read from files",
@@ -21,7 +26,8 @@
             "ru": "iCal читает файлы в формате .ics по URL адресу (Google Calendar или iCal)"
         },
         "authors": [
-            "bluefox <dogafox@gmail.com>"
+            "bluefox <dogafox@gmail.com>",
+            "Jens Maus <mail@jens-maus.de>"
         ],
         "license":                  "MIT",
         "platform":                 "Javascript/Node.js",

--- a/main.js
+++ b/main.js
@@ -201,6 +201,32 @@ function checkiCal(urlOrFile, user, pass, sslignore, calName, cb) {
 
                 // es interessieren nur Termine mit einer Summary und nur Einträge vom Typ VEVENT
                 if ((ev.summary != undefined) && (ev.type === 'VEVENT')) {
+
+                    // check if ev.start is a string and if so we have to convert it
+                    // into a correct Date object
+                    if(typeof(ev.start) === 'string') {
+                      var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(ev.start);
+                      if(comps !== null) {
+                        // No TZ info - assume same timezone as this computer
+                        ev.start = new Date(
+                          comps[1],
+                          parseInt(comps[2], 10)-1,
+                          comps[3]
+                        );
+                      }
+                    }
+                    if(typeof(ev.end) === 'string') {
+                      var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(ev.end);
+                      if(comps !== null) {
+                        // No TZ info - assume same timezone as this computer
+                        ev.end = new Date(
+                          comps[1],
+                          parseInt(comps[2], 10)-1,
+                          comps[3]
+                        );
+                      }
+                    }
+
                     // aha, it is RRULE in the event --> process it
                     if (ev.rrule != undefined) {
                         var options = RRule.parseString(ev.rrule.toString());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.ical",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Allows read information from google calender and from iCal.",
   "author": {
     "name": "bluefox",


### PR DESCRIPTION
This pull request work arounds a problem in the ics parse module which seem to have problems with ics files containing event where the TZID comes before DTSTART/DTEND and thus always returns the ev.start/ev.end in string format. Thus we do the conversion on our own until the ics parser module is fixed.