### PR TITLE
PR to use the 'node-ical' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ Zum Einbinden eines Google Kalenders muss die Kalendereinstellung des Google Kal
 Known BUGS: Probleme mit gleichen UUIDs von iCal Einträgen (bedingt durch Bibliothek); sich wiederholende Termine, in welchen einzelne Termine ausgenommen werden funktionieren nicht. Die Bibliothek verarbeitet keine EXDATES.
 
 ## Changelog
+### 1.3.0 (2017-02-17)
+* (jens-maus) switched ical module to use 'node-ical' which should improve ics format compatibility
+
 ### 1.2.1 (2017-02-11)
 * (jens-maus) applied workaround of ics files with TZID before DATE in DTSTART/DTEND
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,13 @@
 {
     "common": {
         "name":                     "ical",
-        "version":                  "1.2.2",
+        "version":                  "1.3.0",
         "news": {
+            "1.3.0": {
+                "en": "switch to node-ical for better compatibility",
+                "de": "switch to node-ical for better compatibility",
+                "ru": "switch to node-ical for better compatibility"
+            },
             "1.2.2": {
                 "en": "full days with start in the past supported",
                 "de": "full days with start in the past supported",

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@
 
 var utils   = require(__dirname + '/lib/utils'); // Get common adapter utils
 var RRule   = require('rrule').RRule;
-var ical    = require('ical');
+var ical    = require('node-ical');
 var ce      = require('cloneextend');
 var request;
 var fs;

--- a/main.js
+++ b/main.js
@@ -211,31 +211,6 @@ function checkiCal(urlOrFile, user, pass, sslignore, calName, cb) {
                 // es interessieren nur Termine mit einer Summary und nur Einträge vom Typ VEVENT
                 if ((ev.summary != undefined) && (ev.type === 'VEVENT')) {
 
-                    // check if ev.start is a string and if so we have to convert it
-                    // into a correct Date object
-                    if(typeof(ev.start) === 'string') {
-                      var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(ev.start);
-                      if(comps !== null) {
-                        // No TZ info - assume same timezone as this computer
-                        ev.start = new Date(
-                          comps[1],
-                          parseInt(comps[2], 10)-1,
-                          comps[3]
-                        );
-                      }
-                    }
-                    if(typeof(ev.end) === 'string') {
-                      var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(ev.end);
-                      if(comps !== null) {
-                        // No TZ info - assume same timezone as this computer
-                        ev.end = new Date(
-                          comps[1],
-                          parseInt(comps[2], 10)-1,
-                          comps[3]
-                        );
-                      }
-                    }
-
                     // aha, it is RRULE in the event --> process it
                     if (ev.rrule != undefined) {
                         var options = RRule.parseString(ev.rrule.toString());

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/ioBroker/ioBroker.ical"
   },
   "dependencies": {
-      "node-ical": "^0.5.3",
+      "node-ical": "^0.5.4",
       "rrule": "^2.1.0",
       "request": "^2.73.0",
       "cloneextend": "^0.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.ical",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Allows read information from google calender and from iCal.",
   "author": {
     "name": "bluefox",
@@ -18,7 +18,7 @@
     "url": "https://github.com/ioBroker/ioBroker.ical"
   },
   "dependencies": {
-      "ical": "^0.5.0",
+      "node-ical": "^0.5.2",
       "rrule": "^2.1.0",
       "request": "^2.73.0",
       "cloneextend": "^0.0.3"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/ioBroker/ioBroker.ical"
   },
   "dependencies": {
-      "node-ical": "^0.5.2",
+      "node-ical": "^0.5.3",
       "rrule": "^2.1.0",
       "request": "^2.73.0",
       "cloneextend": "^0.0.3"


### PR DESCRIPTION
This PR switches ioBroker.ical to use 'node-ical' rather than 'ical' js module because this integrates important changes/fixes we require. It is API compatible thus only minor changes are required to support it. This change allows to remove some workaround in our own code.