### PR TITLE
Changed force fullday / hide start - end time

### DIFF
--- a/main.js
+++ b/main.js
@@ -329,16 +329,16 @@ function checkDates(ev, endpreview, today, realnow, rule, calName) {
     }
 
     // If force Fullday is set
-	if (adapter.config.forceFullday) {
-		fullday = true;
-		ev.start.setMinutes(0);
-		ev.start.setSeconds(0);
-		ev.start.setHours(0);
+    if (adapter.config.forceFullday && !fullday) {
+        fullday = true;
+        ev.start.setMinutes(0);
+        ev.start.setSeconds(0);
+        ev.start.setHours(0);
         ev.end.setDate(ev.end.getDate() + 1);
         ev.end.setHours(0);
-		ev.end.setMinutes(0);
-		ev.end.setSeconds(0);
-	}
+        ev.end.setMinutes(0);
+        ev.end.setSeconds(0);
+    }
 
     // Full day
     if (fullday) {


### PR DESCRIPTION
Behavior of the "hide start - end time" option changed.

If the event is already fullday dont do anything.
This change is fixing the issue of this post: https://forum.iobroker.net/viewtopic.php?f=22&p=136363#p136323