### PR TITLE
Updated README files: added remarks regarding the Baikal CalDAV+CardDAV server

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Alternatively it is possible to use a local `.ics` file (use absolute path to th
 
 Read english [here](docs/en/README.md).
 
-Siehe deustche [Version hier](docs/de/README.md).
+Siehe deutsche [Version hier](docs/de/README.md).
 
 ## Todo
 * `data.trigger` doesn't support `check` option

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -74,6 +74,9 @@ Zum Einbinden eines Google Kalenders muss die Kalendereinstellung des Google Kal
 #### OwnCloud Kalender
 Zum Einbinden von gesharten Kalendern einer OwnCloud muss man dort in der Kalenderansicht in OwnCloud diesen Kalender als gesharten Kalender freigeben und dort den Link zum Kalender anzeigen lassen und diese URL (https://owncloud.xxxxxx.de/remote.php/dav/calendars/USER/xxxxxxx_shared_by_xxxxxx?export) entsprechend in den ioBroker.ical Adapter mit Nutzername und Passwort angeben.
 
+#### Baikal CalDAV+CardDAV Server
+Der Baikal-Server bringt das "ics-export"-Plugin mit welches den Export eines Kalenders in eine gesammelte ICal-Datei erlaubt. Dieses Plugin wird direkt über die URL ausgewählt und erlaubt eine problemlose Zusammenarbeit mit dem vorliegenden ioBroker-Adapter. Wichtig ist der Exportfilter, welcher einfach an die Kalender-URL angehangen zu werden braucht (`https://SERVER/baikal/cal.php/calendars/path/to/calendar?export&accept=ical`). Bei Anmeldeproblemen bitte in den Admin-Einstellungen der Web-UI des Baikal-Servers unter `Settings` den `WebDAV authentication type` von `DIGEST` auf `BASIC` stellen.
+
 ### CSS
 In dem generierten HTML sind zwei Arten von CSS-Klassen enthalten, um Gestaltungsfreiheit zu ermöglichen.
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -76,6 +76,9 @@ To include a Google Calendar, you must go to the Google Calendar calendar settin
 #### OwnCloud Calendar
 To include a hardcooked calendar of an OwnCloud, you have to approve this calendar in the calendar view in OwnCloud as a hardcourt calendar and there the link.
 
+#### Baikal lightweight CalDAV+CardDAV Server
+The Baikal server offers the "ics-export" plugin that allows to export a calendar as a single ICal file. This export plugin is selected with the URL and allows seamless integration with this ioBroker adaptor. Please add the export filter to the URL of your calendar (`https://SERVER/baikal/cal.php/calendars/path/to/calendar?export&accept=ical`). If you encounter authentication issues, please change the `WebDAV authentication type` from `DIGEST` to `BASIC` in the admin settings of the WebUI of the Baikal server.
+
 ### CSS
 In the generated HTML two kind of css classes are included to allow design freedom.
 


### PR DESCRIPTION
I'm using the lightweight Baikal CalDAV+CardDAV server (https://sabre.io/baikal/) and had some issues getting this adaptor to be able to access my calendars. This pull request adds the results of my research to the README files to provide that information to other users. If following these instructions, the calendars are imported and the adaptor works very well.

However, I'm having issues with line breaks in all three of my edited files. My "git diff" command showed "^M" characters trailing my edited lines indicating a line break mode problem. I tried multiple editors but was not able to fix this without changing the whole file to a different format (then "git diff" wanted to change every line). No idea, something seems odd with these files, or my editors. If in doubt, please check locally before merging.

Regards,
Florian