### PR TITLE
Added feature to ignore case when events are searched in calendars

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -128,6 +128,15 @@
                     <label class="translate" for="daysPast">Past days:</label>
                 </div>
             </div>
+			<div class="row">
+                <div class="col s12 m4">
+                    <input class="value" id="ignoreCaseInEventname" type="checkbox" />
+                    <label class="translate" for="ignoreCaseInEventname">Ignore case for event-search:</label>
+                </div>
+                <div class="col s12 m4">
+				
+                </div>
+            </div>
         </div>
         <div id="tab-html" class="col s12 page">
             <div class="row">

--- a/admin/words.js
+++ b/admin/words.js
@@ -13,6 +13,17 @@ systemDictionary = {
         "es": "Configuración del adaptador iCal",
         "pl": "Ustawienia adaptera iCal"
     },
+    "Ignore case for event-search:": {
+        "en": "Ignore case for event-search",
+        "de": "Groß-/Kleinschreibung bei Event-Suche ignorieren",
+        "ru": "Ignore case for event-search",
+        "pt": "Ignore case for event-search",
+        "nl": "Ignore case for event-search",
+        "fr": "Ignore case for event-search",
+        "it": "Ignore case for event-search",
+        "es": "Ignore case for event-search",
+        "pl": "Ignore case for event-search"
+    },
     "Preview days:": {
         "en": "Preview days",
         "de": "Tagesvorschau",

--- a/io-package.json
+++ b/io-package.json
@@ -207,6 +207,7 @@
         "forceFullday": false,
         "hideYear": false,
         "arrowAlreadyStarted": true,
+        "ignoreCaseInEventname": false,
         "calendars": [
             {
                 "name": "calendar1",

--- a/main.js
+++ b/main.js
@@ -593,6 +593,7 @@ function colorizeDates(date, today, tomorrow, dayafter, col, calName) {
 }
 
 function checkForEvents(reason, event, realnow) {
+	const ignoreCaseInEventname = adapter.config.ignoreCaseInEventname;
     const oneDay = 24 * 60 * 60 * 1000;
     // show unknown events
     let result = true;
@@ -602,7 +603,7 @@ function checkForEvents(reason, event, realnow) {
     // check if event exists in table
     for (let i = 0; i < events.length; i++) {
         const ev = events[i];
-        if (reason.includes(ev.name)) {
+        if ((reason.includes(ev.name)) || (ignoreCaseInEventname && (reason.toLowerCase().includes(ev.name.toLowerCase())))) {
             // check if event should shown
             result = ev.display;
             adapter.log.debug('found event in table: ' + ev.name);


### PR DESCRIPTION
As I struggled often to recall the case I used in event matches and therefore had wrong behavior, I needed a feature to ignore case if required.
I added a minimal solution and tested it in my own environment successfully. 
A new adapter setting "ignoreCaseInEventname" was introduced which is false per default, so an update of the adapter would not change the existing functionality and user experience.

I was only able to add the German and English translation for this setting. More help required to add the other translations.