### PR TITLE
Outlook- und office365-Kalender: Bad request - HTTP-Status 400 #423

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,7 +172,10 @@ function getICal(urlOrFile, user, pass, sslignore, calName, cb) {
     } else {
         // Find out whether SSL certificate errors shall be ignored
         const options = {
-            uri: urlOrFile
+            uri: urlOrFile,
+	    headers: {
+		'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36'
+		}
         };
 
         if (sslignore === 'ignore' || sslignore === 'true' || sslignore === true) {


### PR DESCRIPTION
Lösung des o.g. issues nach einer Idee von @langeneggerma: Es wird ein header mit user-agent ergänzt.
Längerfristig wäre es vlt. sinnvoll, den user-agent variabel als Parameter der Instanz / des Adapters zu übergeben.

Thread im Forum: https://forum.iobroker.net/topic/55519/ical-outlook-live-com-bad-request