### PR TITLE
Replace cloneextend event cloning

### DIFF
--- a/lib/cloneEvent.js
+++ b/lib/cloneEvent.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Copy an iCalendar event before changing occurrence-specific top-level properties.
+ *
+ * A shallow copy is intentional. Values created by node-ical, such as RRule instances,
+ * must retain their prototypes. Some parser-owned dictionaries also deliberately have
+ * a null prototype and cannot be processed by clone utilities that call
+ * `value.hasOwnProperty()`.
+ *
+ * @template {Record<string, unknown>} T
+ * @param {T} event event returned by node-ical
+ * @returns {T} event copy
+ */
+function cloneEvent(event) {
+    return { ...event };
+}
+
+module.exports = cloneEvent;

--- a/main.js
+++ b/main.js
@@ -10,8 +10,7 @@ const os = require('node:os');
 
 const utils = require('@iobroker/adapter-core');
 const adapterName = require('./package.json').name.split('.').pop();
-
-const ce = require('cloneextend');
+const cloneEvent = require('./lib/cloneEvent');
 
 let adapter;
 let stopped = false;
@@ -625,8 +624,9 @@ endpreview: ${endpreview}`);
                 // event within the time window
                 if (dates.length > 0) {
                     for (let i = 0; i < dates.length; i++) {
-                        // use deep-copy otherwise setDate etc. overwrites data from different events
-                        let ev2 = ce.clone(ev);
+                        // Copy the event before changing occurrence-specific top-level properties.
+                        // Keep parser-owned values such as RRule instances intact.
+                        let ev2 = cloneEvent(ev);
 
                         // we have to move the start time of our clone
                         // to a time relative to the timezone of the start time
@@ -672,7 +672,7 @@ endpreview: ${endpreview}`);
                             for (const dOri in ev.recurrences) {
                                 const recurEvent = ev.recurrences[dOri];
                                 if (recurEvent.recurrenceid.getTime() === ev2.start.getTime()) {
-                                    ev2 = ce.clone(recurEvent);
+                                    ev2 = cloneEvent(recurEvent);
                                     adapter.log.debug(
                                         `   ${i}: different recurring found replaced with Event:${ev2.start} ${ev2.end}`,
                                     );

--- a/main.test.js
+++ b/main.test.js
@@ -1,30 +1,29 @@
 'use strict';
 
-/**
- * This is a dummy TypeScript test file using chai and mocha
- *
- * It's automatically excluded from npm and its build output is excluded from both git and npm.
- * It is advised to test all your modules with accompanying *.test.js-files
- */
+const assert = require('node:assert/strict');
+const cloneEvent = require('./lib/cloneEvent');
 
-// tslint:disable:no-unused-expression
+describe('cloneEvent', () => {
+    it('copies top-level event properties without cloning parser-owned values', () => {
+        const parserDictionary = Object.assign(Object.create(null), { language: 'en' });
+        const rrule = { between: () => [] };
+        const event = {
+            summary: { val: 'Test event', params: parserDictionary },
+            start: new Date('2026-07-20T08:00:00.000Z'),
+            end: new Date('2026-07-20T09:00:00.000Z'),
+            rrule,
+        };
 
-const { expect } = require('chai');
-// import { functionToTest } from "./moduleToTest";
+        const copy = cloneEvent(event);
 
-describe('module to test => function to test', () => {
-    // initializing logic
-    const expected = 5;
+        assert.notStrictEqual(copy, event);
+        assert.strictEqual(copy.summary, event.summary);
+        assert.strictEqual(copy.rrule, rrule);
 
-    it(`should return ${expected}`, () => {
-        const result = 5;
-        // assign result a value from functionToTest
-        expect(result).to.equal(expected);
-        // or using the should() syntax
-        result.should.equal(expected);
+        copy.start = new Date('2026-07-27T08:00:00.000Z');
+        copy.end = new Date('2026-07-27T09:00:00.000Z');
+
+        assert.equal(event.start.toISOString(), '2026-07-20T08:00:00.000Z');
+        assert.equal(event.end.toISOString(), '2026-07-20T09:00:00.000Z');
     });
-    // ... more tests => it
-
 });
-
-// ... more test suites => describe

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.4.1",
-        "cloneextend": "^0.0.3",
         "json-schema": "^0.4.0",
         "node-ical": "^0.27.0"
       },
@@ -3150,14 +3149,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/cloneextend": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/cloneextend/-/cloneextend-0.0.3.tgz",
-      "integrity": "sha512-qeY0VknVTjzllPs1wHprcaXID7abtzFF4xoXjHUKWifdbd4cF+oYtjIhRB9Lrl4s32K3uQG9QizBixM1WhSwrQ==",
-      "engines": {
-        "node": ">0.2.0"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.4.1",
-    "cloneextend": "^0.0.3",
     "json-schema": "^0.4.0",
     "node-ical": "^0.27.0"
   },


### PR DESCRIPTION
## What changed

- replace `cloneextend` with a focused shallow event copy
- preserve parser-owned values such as `RRule` instances and null-prototype dictionaries
- remove the obsolete `cloneextend` dependency
- add a regression test covering null-prototype nested values and occurrence-specific date replacement

## Why

`cloneextend` recursively calls `value.hasOwnProperty()`. Current `node-ical` results can contain null-prototype dictionaries, which intentionally do not expose that method. Expanding recurring events could therefore terminate the adapter with `TypeError: b.hasOwnProperty is not a function`.

The adapter only replaces top-level fields such as `start` and `end` while expanding occurrences. A shallow event copy provides the required isolation without traversing parser-owned values or stripping prototypes from class instances.

## Impact

Recurring events containing null-prototype parser data can be processed without crashing. `RRule` and other parser-created values retain their original behavior.

## Validation

- ESLint: passed
- focused Mocha regression test: passed
- Node.js syntax checks for `main.js` and `lib/cloneEvent.js`: passed
- package metadata consistency check: passed

The complete existing Mocha setup could not be executed locally because the repository references undeclared test dependencies (`sinon-chai`, and previously `chai`). The new regression test uses `node:assert` and passes independently.
