### PR TITLE
fix: apply daysPast to events with a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Sentry reporting, starting with js-controller 3.0, means that this adapter can u
 	Placeholder for the next version (at the beginning of the line):
 	### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+* (typhosj) Events with a time are kept for the configured past days as well (daysPast)
+
 ### 1.21.0 (2026-07-21)
 * (jens-maus) Update node-ical from 0.26.1 to 0.27.1
 

--- a/main.js
+++ b/main.js
@@ -833,10 +833,14 @@ LOCATION:${location}`;
         adapter.log.debug(`Event (time) processing. Start: ${ev.start} End: ${ev.end}`);
 
         // Event with time
-        // Start time >= startpreview && Start time < preview time && End time >= now
+        // Start time >= startpreview && Start time < preview time && End time >= pastLimit
+        // Without configured past days an event that already ended is not shown (pastLimit = now).
+        // With daysPast > 0 the past window applies to events with a time as well, so they stay
+        // visible until startpreview, exactly like full day events do.
+        const pastLimit = adapter.config.daysPast > 0 ? startpreview : realnow;
         if (
-            (ev.start >= startpreview && ev.start < endpreview && ev.end >= realnow) ||
-            (ev.end >= realnow && ev.end <= endpreview) ||
+            (ev.start >= startpreview && ev.start < endpreview && ev.end >= pastLimit) ||
+            (ev.end >= pastLimit && ev.end <= endpreview) ||
             (ev.start < realnow && ev.end > realnow)
         ) {
             // Add to list only if not hidden

--- a/test/data/.gitignore
+++ b/test/data/.gitignore
@@ -9,3 +9,4 @@
 /filter.ics
 /filter_regex.ics
 /event.ics
+/past.ics

--- a/test/integration.js
+++ b/test/integration.js
@@ -12,6 +12,7 @@ const setupIcsFilter = require(__dirname + '/lib/setupIcsFilter');
 const setupIcsFilterRegex = require(__dirname + '/lib/setupIcsFilterRegex');
 const setupIcsForceFullDay = require(__dirname + '/lib/setupIcsForceFullDay');
 const setupIcsRecurring = require(__dirname + '/lib/setupIcsRecurring');
+const setupIcsPast = require(__dirname + '/lib/setupIcsPast');
 
 async function startAdapterAndWaitForStop(harness) {
     return new Promise(resolve => {
@@ -420,6 +421,49 @@ tests.integration(path.join(__dirname, '..'), {
 
                 expect(eventTable).to.be.an('array');
                 expect(eventTable).to.have.lengthOf.at.least(25); // 364 days preview, every 2 weeks
+
+            });
+        });
+
+        suite('Test Past', getHarness => {
+            /**
+             * @type {IntegrationTestHarness}
+             */
+            let harness;
+            before(async function () {
+                this.timeout(60000);
+
+                setupIcsPast.setup();
+
+                harness = getHarness();
+                harness.changeAdapterConfig(harness.adapterName, setupIcsPast.getInstanceConfig());
+
+                return startAdapterAndWaitForStop(harness);
+            });
+
+            it('Check event table', async function () {
+
+                /*
+                    * PastFulldayEvent (yesterday, full day)
+                    * PastTimedEvent (yesterday, with time, already over)
+                    * FutureTimedEvent (tomorrow, with time)
+                    * TooOldEvent is five days old and out of daysPast = 2
+                */
+                const stateDataTable = await harness.states.getStateAsync(`${harness.adapterName}.0.data.table`);
+                const eventTable = JSON.parse(stateDataTable.val);
+
+                expect(eventTable).to.be.an('array');
+                expect(eventTable.map(entry => entry.event)).to.be.deep.equal([
+                    'PastFulldayEvent',
+                    'PastTimedEvent',
+                    'FutureTimedEvent',
+                ]);
+
+                expect(eventTable[1]._allDay).to.be.false;
+                expect(eventTable[1].date).to.endsWith('. 10:00-11:00');
+
+                const stateDataCountYesterday = await harness.states.getStateAsync(`${harness.adapterName}.0.data.countYesterday`);
+                expect(stateDataCountYesterday.val).to.be.equal(2);
 
             });
         });

--- a/test/lib/setupIcsPast.js
+++ b/test/lib/setupIcsPast.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const fs = require('node:fs');
+const { newDate } = require('./setupDate');
+
+const fileName = __dirname + '/../data/past.ics';
+
+module.exports.getInstanceConfig = function() {
+    return {
+        native: {
+            daysPreview: 7,
+            daysPast: 2,
+            fulltime: '',
+            replaceDates: false,
+            hideYear: true,
+            calendars: [
+                {
+                    name: 'calendar-past',
+                    url: fileName,
+                    user: '',
+                    pass: '',
+                    sslignore: 'ignore',
+                    color: 'orange'
+                }
+            ],
+            events: []
+        }
+    };
+};
+
+module.exports.setup = function () {
+    if (fs.existsSync(fileName)) {
+        fs.unlinkSync(fileName);
+    }
+
+    // five days ago - outside of the configured past window
+    const dOut = newDate().minus({day: 5});
+
+    // yesterday - inside of the configured past window
+    const dPast = newDate().minus({day: 1});
+
+    // today
+    const dToday = newDate();
+
+    // tomorrow
+    const dNext = newDate().plus({day: 1});
+
+    const date = d => d.toFormat('yyyyMMdd');
+
+    let data = fs.readFileSync(__dirname + '/../data/calender_head_template.ics').toString();
+
+    data += 'X-WR-CALNAME:Integration Test Calendar\n';
+    data += 'X-WR-TIMEZONE:' + dToday.zoneName + '\n';
+
+    // event with time, already over and outside of the past window
+    data += 'BEGIN:VEVENT\n';
+    data += 'DTSTART:' + date(dOut) + 'T100000\n';
+    data += 'DTEND:' + date(dOut) + 'T110000\n';
+    data += 'DTSTAMP:20111213T124028Z\n';
+    data += 'UID:8ab00ad3a214f7369e7a95f01@calendarlabs.com\n';
+    data += 'CREATED:20111213T123901Z\n';
+    data += 'DESCRIPTION:TooOldEvent\n';
+    data += 'LAST-MODIFIED:20111213T123901Z\n';
+    data += 'LOCATION:\n';
+    data += 'SEQUENCE:0\n';
+    data += 'STATUS:CONFIRMED\n';
+    data += 'SUMMARY:TooOldEvent\n';
+    data += 'TRANSP:OPAQUE\n';
+    data += 'END:VEVENT\n';
+
+    // fullday event of yesterday
+    data += 'BEGIN:VEVENT\n';
+    data += 'DTSTART;VALUE=DATE:' + date(dPast) + '\n';
+    data += 'DTEND;VALUE=DATE:' + date(dToday) + '\n';
+    data += 'DTSTAMP:20111213T124028Z\n';
+    data += 'UID:8ab00ad3a214f7369e7a95f02@calendarlabs.com\n';
+    data += 'CREATED:20111213T123901Z\n';
+    data += 'DESCRIPTION:PastFulldayEvent\n';
+    data += 'LAST-MODIFIED:20111213T123901Z\n';
+    data += 'LOCATION:\n';
+    data += 'SEQUENCE:0\n';
+    data += 'STATUS:CONFIRMED\n';
+    data += 'SUMMARY:PastFulldayEvent\n';
+    data += 'TRANSP:TRANSPARENT\n';
+    data += 'END:VEVENT\n';
+
+    // event with time of yesterday, already over but inside of the past window
+    data += 'BEGIN:VEVENT\n';
+    data += 'DTSTART:' + date(dPast) + 'T100000\n';
+    data += 'DTEND:' + date(dPast) + 'T110000\n';
+    data += 'DTSTAMP:20111213T124028Z\n';
+    data += 'UID:8ab00ad3a214f7369e7a95f03@calendarlabs.com\n';
+    data += 'CREATED:20111213T123901Z\n';
+    data += 'DESCRIPTION:PastTimedEvent\n';
+    data += 'LAST-MODIFIED:20111213T123901Z\n';
+    data += 'LOCATION:\n';
+    data += 'SEQUENCE:0\n';
+    data += 'STATUS:CONFIRMED\n';
+    data += 'SUMMARY:PastTimedEvent\n';
+    data += 'TRANSP:OPAQUE\n';
+    data += 'END:VEVENT\n';
+
+    // event with time of tomorrow
+    data += 'BEGIN:VEVENT\n';
+    data += 'DTSTART:' + date(dNext) + 'T100000\n';
+    data += 'DTEND:' + date(dNext) + 'T110000\n';
+    data += 'DTSTAMP:20111213T124028Z\n';
+    data += 'UID:8ab00ad3a214f7369e7a95f04@calendarlabs.com\n';
+    data += 'CREATED:20111213T123901Z\n';
+    data += 'DESCRIPTION:FutureTimedEvent\n';
+    data += 'LAST-MODIFIED:20111213T123901Z\n';
+    data += 'LOCATION:\n';
+    data += 'SEQUENCE:0\n';
+    data += 'STATUS:CONFIRMED\n';
+    data += 'SUMMARY:FutureTimedEvent\n';
+    data += 'TRANSP:OPAQUE\n';
+    data += 'END:VEVENT\n';
+
+    data += 'END:VCALENDAR\n';
+
+    fs.writeFileSync(fileName, data);
+};


### PR DESCRIPTION
Fixes #937

### What was wrong

`checkDates()` required `ev.end >= realnow` in all three conditions of the "Event with time" branch, so an event that had ended could never pass the window check. `startpreview` - the only place where `daysPast` is applied - was therefore ineffective for these events: `daysPast` worked for full day events only, and `data.countYesterday` could only ever count full day events.

### What this changes

```js
const pastLimit = adapter.config.daysPast > 0 ? startpreview : realnow;
if (
    (ev.start >= startpreview && ev.start < endpreview && ev.end >= pastLimit) ||
    (ev.end >= pastLimit && ev.end <= endpreview) ||
    (ev.start < realnow && ev.end > realnow)
) {
```

Events with a time now honour the past window, but only when one is configured. With the default `daysPast: 0` the limit stays `realnow`, so the behaviour of existing installations does not change - the condition is then identical to the old one.

With `daysPast > 0` two things become visible that were not before: events with a time that have ended stay in `data.table` / `data.html` / `data.text` until `startpreview`, and `data.countYesterday` counts them. Events of type `today` in the events table can now also turn true for an event that already ended today; `now` and `later` are unaffected, they compare against `realnow` themselves.

### Test

New integration suite `Test Past` with `daysPast: 2`, covering a full day event of yesterday, an event with a time of yesterday (already over, inside the window) and one five days old (outside the window), plus `data.countYesterday`.

- with this change: `1 passing`
- with the current `main.js`: `1 failing` - `expected [ 'PastFulldayEvent', 'FutureTimedEvent' ] to deeply equal [ 'PastFulldayEvent', 'PastTimedEvent', 'FutureTimedEvent' ]`
